### PR TITLE
fix: update regex to match decimal percents

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -40,7 +40,7 @@ const availableColorsReStr = '(:?' + availableColors.join('|') + ')'
 function getCoverageRe() {
   // note, Shields.io escaped '-' with '--'
   const coverageRe = new RegExp(
-    `https://img\\.shields\\.io/badge/code--coverage-\\d+%25-${availableColorsReStr}`,
+    `https://img\\.shields\\.io/badge/code--coverage-[1-9]\d?|\d+\.?\d+%25-${availableColorsReStr}`,
   )
   return coverageRe
 }
@@ -71,7 +71,7 @@ function getCoverageFromReadme() {
   const readmeText = fs.readFileSync(readmeFilename, 'utf8')
 
   const coverageRe = new RegExp(
-    `https://img\\.shields\\.io/badge/code--coverage-(\\d+)%25-${availableColorsReStr}`,
+    `https://img\\.shields\\.io/badge/code--coverage-([1-9]\d?|\d+\.?\d+)%25-${availableColorsReStr}`,
   )
   const matches = coverageRe.exec(readmeText)
 


### PR DESCRIPTION
fixes #19

From regex101.com
![image](https://user-images.githubusercontent.com/9759954/86371033-69663b80-bc4e-11ea-9ac5-8e1ab80a0cc1.png)
